### PR TITLE
Prevent the next() being caught recursive

### DIFF
--- a/src/middlewares/podcast/getPodcastDurationInSeconds.js
+++ b/src/middlewares/podcast/getPodcastDurationInSeconds.js
@@ -13,9 +13,8 @@ module.exports = async (_req, res, next) => {
     const duration = await getDuration(filePath);
 
     res.locals.durationInSeconds = Math.ceil(duration);
-
-    next();
   } catch (err) {
-    next(err);
+    return next(err);
   }
+  next();
 };


### PR DESCRIPTION
Prevent the call-back 'next()' method being caught as well.

If an error would be throws in `next()`, `next()` will be called a second time, with it's own error.